### PR TITLE
ToF Electron Current Density Sign Correction

### DIFF
--- a/src/OSC_Sim.cpp
+++ b/src/OSC_Sim.cpp
@@ -2756,7 +2756,7 @@ namespace Excimontec {
 					for (auto const &item : electrons) {
 						// Get electron site energy and position for previous timestep
 						int electron_index = (int)distance(transient_electron_tags.begin(), find(transient_electron_tags.begin(), transient_electron_tags.end(), item.getTag()));
-						transient_velocities[index] += (1e-7*lattice.getUnitSize()*(item.getCoords().z - ToF_positions_prev[electron_index])) / ((getTime() - Transient_creation_time) - transient_times[Transient_index_prev]);
+						transient_velocities[index] += abs(1e-7*lattice.getUnitSize()*(item.getCoords().z - ToF_positions_prev[electron_index])) / ((getTime() - Transient_creation_time) - transient_times[Transient_index_prev]);
 						transient_electron_energies[index] += getSiteEnergy(item.getCoords());
 						transient_electron_energies_prev[electron_index] = getSiteEnergy(item.getCoords());
 						ToF_positions_prev[electron_index] = item.getCoords().z;
@@ -2769,7 +2769,7 @@ namespace Excimontec {
 					for (auto const &item : holes) {
 						// Get hole site energy and position for previous timestep
 						int hole_index = (int)distance(transient_hole_tags.begin(), find(transient_hole_tags.begin(), transient_hole_tags.end(), item.getTag()));
-						transient_velocities[index] += (1e-7*lattice.getUnitSize()*(item.getCoords().z - ToF_positions_prev[hole_index])) / ((getTime() - Transient_creation_time) - transient_times[Transient_index_prev]);
+						transient_velocities[index] += abs(1e-7*lattice.getUnitSize()*(item.getCoords().z - ToF_positions_prev[hole_index])) / ((getTime() - Transient_creation_time) - transient_times[Transient_index_prev]);
 						transient_hole_energies[index] += getSiteEnergy(item.getCoords());
 						transient_hole_energies_prev[hole_index] = getSiteEnergy(item.getCoords());
 						ToF_positions_prev[hole_index] = item.getCoords().z;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1345,6 +1345,8 @@ namespace OSC_SimTests {
 		EXPECT_NEAR(expected_mobility, vector_avg(mobility_data), 1.5e-1*expected_mobility);
 		// Check relaxed mobility value from the transient data
 		auto velocities = sim.getToFTransientVelocities();
+		// Check sign of transient hole velocity data
+		EXPECT_GT(velocities[0], 0);
 		auto counts_data = sim.getToFTransientCounts();
 		int N_points = 5;
 		auto counts_end_it = find_if(counts_data.begin(), counts_data.end(), [](int val) {return val < 5; });
@@ -1444,6 +1446,9 @@ namespace OSC_SimTests {
 		dim = 3.0;
 		expected_mobility = (params.R_polaron_hopping_donor*exp(-2.0*params.Polaron_localization_donor)*1e-14) * (2.0 / 3.0) * (tgamma((dim + 1.0) / 2.0) / tgamma(dim / 2.0)) * (1.0 / (K_b*params.Temperature));
 		EXPECT_NEAR(expected_mobility, vector_avg(mobility_data), 1.5e-1*expected_mobility);
+		// Check sign of transient electron velocity data
+		velocities = sim.getToFTransientVelocities();
+		EXPECT_GT(velocities[0], 0);
 		// Check charge extraction map output
 		auto vec = sim.getChargeExtractionMap(false);
 		EXPECT_EQ(vec[0], "X-Position,Y-Position,Extraction Probability");


### PR DESCRIPTION
-Resolves #73 

OSC_Sim class:
-Updated updateTransientData function to take the absolute value of the z-displacement so that the carrier velocity is always positive

tests:
-Added tests to OSC_SimTest ToFTests to make sure that the sign of the charge carrier velocity data is positive